### PR TITLE
Improved: Add subscribe email on website mailing list page (OFBIZ-10729)

### DIFF
--- a/mailing-lists.html
+++ b/mailing-lists.html
@@ -127,20 +127,32 @@
       <div class="container">
         <div class="row">
           <section class="mb15 clearfix">
-            <div class="span6"> <img src="images/Subscribe.jpg" alt="subscribe to our mailing lists"/> </div>
-            <div class="span6">
-              <h2>Subscribe to Our Mailing Lists</h2>
-              <div class="divider"><span></span></div>
+            <h2>Subscribe to Our Mailing Lists</h2>
+            <div class="divider"><span></span></div>
+            <div class="row-fluid mb15">
+              <div class="span6">
               <p>We welcome everyone who would like to join our community and participate in our mailing lists. We expect that everyone respects the <a href="//www.apache.org/dev/contrib-email-tips.html">mailing list participation guidelines </a> and the <a href="//apache.org/foundation/policies/conduct.html">ASF Code of Conduct </a>.</p>
         <p>To subscribe to a mailing list please:
     <ul class="iconsList">
     <li><i class="icon-pin"></i>Click the button of the mailing list you want to subscribe to</li>
     <li><i class="icon-pin"></i>On the following page, click the 'Subscribe' button </li>
     <li><i class="icon-pin"></i>Send the automatically created email from your email client</li>
-    <li><i class="icon-pin"></i>You will receive an email about the mailing list manager program (EZMLM)</li>
+    <li><i class="icon-pin"></i>Reply to the email from the mailing list manager program (EZMLM)</li>
     <li><i class="icon-pin"></i>Congratulations! You are now subscribed</li>
     </ul>
+                  <h3>Alternate steps:</h3>
+                  <p>To subscribe to any of the following lists, please send an empty, subjectless email to mailing list subscribe addresses.</p>
+                  <ul class="iconsList">
+                    <li><i class="icon-pin"></i> user-subscribe@ofbiz.apache.org</li>
+                    <li><i class="icon-pin"></i> dev-subscribe@ofbiz.apache.org</li>
+                    <li><i class="icon-pin"></i> commits-subscribe@ofbiz.apache.org</li>
+                    <li><i class="icon-pin"></i> notifications-subscribe@ofbiz.apache.org</li>
+                  </ul>
+                  <p>Then, reply to the email from the mailing list manager program (EZMLM) to confirm subscribe.</p>
+                  <p>Congratulations! You are now subscribed.</p>
         </div>
+        <div class="span6"> <img src="images/Subscribe.jpg" alt="subscribe to our mailing lists"/> </div>
+            </div>
           </section>
           <section class="span12 mb15">
             <div class="row-fluid mb15">
@@ -154,13 +166,15 @@
                   <li><i class="icon-check"></i> What did you expect as results?</li>
                   <li><i class="icon-check"></i> What you actually got as results?</li>
                  </ul>  
-                <a class="btn btnSmall" href="//lists.apache.org/list.html?user@ofbiz.apache.org">User List</a> </div>
+                <a class="btn btnSmall" href="//lists.apache.org/list.html?user@ofbiz.apache.org">User List</a>
+                </div>
        <div class="span6">
                   <h3 class="mediumIconH3"><span class="iconWrapper iconMedium"><i class="icon-cog-alt"></i></span> Developer Mailing List</h3>
                    <p>The developer list is strictly for topics related to the design and development of the OFBiz Project itself.</p>
       <p><i class="icon-info-circle"></i>Please don't ask questions relevant to User Mailing List in this Mailing List.</p>
        <p>If you are not sure to which list to post to then use the User Mailing List.</p>
-                  <a class="btn btnSmall" href="//lists.apache.org/list.html?dev@ofbiz.apache.org">Developer List</a>
+           <a class="btn btnSmall" href="//lists.apache.org/list.html?dev@ofbiz.apache.org">Developer List</a>
+
     </div>
             </div>
             <div class="row-fluid">
@@ -202,6 +216,7 @@
        <li><i class="icon-pin"></i> commits-unsubscribe@ofbiz.apache.org</li>
        <li><i class="icon-pin"></i> notifications-unsubscribe@ofbiz.apache.org</li>
                 </ul>
+                <p>Then, reply to the email from the mailing list manager program (EZMLM) to confirm unsubscribe.</p>
            </section>
 
         </div>

--- a/template/page/mailing-lists.tpl.php
+++ b/template/page/mailing-lists.tpl.php
@@ -16,20 +16,32 @@
       <div class="container">
         <div class="row">
           <section class="mb15 clearfix">
-            <div class="span6"> <img src="images/Subscribe.jpg" alt="subscribe to our mailing lists"/> </div>
-            <div class="span6">
-              <h2>Subscribe to Our Mailing Lists</h2>
-              <div class="divider"><span></span></div>
+            <h2>Subscribe to Our Mailing Lists</h2>
+            <div class="divider"><span></span></div>
+            <div class="row-fluid mb15">
+              <div class="span6">
               <p>We welcome everyone who would like to join our community and participate in our mailing lists. We expect that everyone respects the <a href="//www.apache.org/dev/contrib-email-tips.html">mailing list participation guidelines </a> and the <a href="//apache.org/foundation/policies/conduct.html">ASF Code of Conduct </a>.</p>
         <p>To subscribe to a mailing list please:
     <ul class="iconsList">
     <li><i class="icon-pin"></i>Click the button of the mailing list you want to subscribe to</li>
     <li><i class="icon-pin"></i>On the following page, click the 'Subscribe' button </li>
     <li><i class="icon-pin"></i>Send the automatically created email from your email client</li>
-    <li><i class="icon-pin"></i>You will receive an email about the mailing list manager program (EZMLM)</li>
+    <li><i class="icon-pin"></i>Reply to the email from the mailing list manager program (EZMLM)</li>
     <li><i class="icon-pin"></i>Congratulations! You are now subscribed</li>
     </ul>
+                  <h3>Alternate steps:</h3>
+                  <p>To subscribe to any of the following lists, please send an empty, subjectless email to mailing list subscribe addresses.</p>
+                  <ul class="iconsList">
+                    <li><i class="icon-pin"></i> user-subscribe@ofbiz.apache.org</li>
+                    <li><i class="icon-pin"></i> dev-subscribe@ofbiz.apache.org</li>
+                    <li><i class="icon-pin"></i> commits-subscribe@ofbiz.apache.org</li>
+                    <li><i class="icon-pin"></i> notifications-subscribe@ofbiz.apache.org</li>
+                  </ul>
+                  <p>Then, reply to the email from the mailing list manager program (EZMLM) to confirm subscribe.</p>
+                  <p>Congratulations! You are now subscribed.</p>
         </div>
+        <div class="span6"> <img src="images/Subscribe.jpg" alt="subscribe to our mailing lists"/> </div>
+            </div>
           </section>
           <section class="span12 mb15">
             <div class="row-fluid mb15">
@@ -43,13 +55,15 @@
                   <li><i class="icon-check"></i> What did you expect as results?</li>
                   <li><i class="icon-check"></i> What you actually got as results?</li>
                  </ul>  
-                <a class="btn btnSmall" href="//lists.apache.org/list.html?user@ofbiz.apache.org">User List</a> </div>
+                <a class="btn btnSmall" href="//lists.apache.org/list.html?user@ofbiz.apache.org">User List</a>
+                </div>
        <div class="span6">
                   <h3 class="mediumIconH3"><span class="iconWrapper iconMedium"><i class="icon-cog-alt"></i></span> Developer Mailing List</h3>
                    <p>The developer list is strictly for topics related to the design and development of the OFBiz Project itself.</p>
       <p><i class="icon-info-circle"></i>Please don't ask questions relevant to User Mailing List in this Mailing List.</p>
        <p>If you are not sure to which list to post to then use the User Mailing List.</p>
-                  <a class="btn btnSmall" href="//lists.apache.org/list.html?dev@ofbiz.apache.org">Developer List</a>
+           <a class="btn btnSmall" href="//lists.apache.org/list.html?dev@ofbiz.apache.org">Developer List</a>
+
     </div>
             </div>
             <div class="row-fluid">
@@ -91,6 +105,7 @@
        <li><i class="icon-pin"></i> commits-unsubscribe@ofbiz.apache.org</li>
        <li><i class="icon-pin"></i> notifications-unsubscribe@ofbiz.apache.org</li>
                 </ul>
+                <p>Then, reply to the email from the mailing list manager program (EZMLM) to confirm unsubscribe.</p>
            </section>
 
         </div>


### PR DESCRIPTION
Currently, we have a link of lists.apache.org for subscribing mailing list,
When a user visited lists.apache.org website it has the option to subscribe, this tries to open email client, if no email client setup on a user machine, so its difficult to subscribe.

We can add an alternate option as well along with lists.apache.org link. A simple text with subscribe email address.