### PR TITLE
Improved: Sync developers.tpl.php template with merged HTML changes from #15

### DIFF
--- a/template/page/developers.tpl.php
+++ b/template/page/developers.tpl.php
@@ -20,6 +20,7 @@
             <ul  id="subnav" class="nav nav-stacked sidenav scrollspyNav">
               <li> <a href="#DevPreq"> Pre-Requisites </a> </li>
               <li> <a href="#DevDownld"> Download </a> </li>
+              <li> <a href="#DevGradle"> Initialize Gradle Wrapper </a> </li>
               <li> <a href="#DevBldRun"> Build and Run </a> </li>
         <li> <a href="#DevRepo"> Browse Repository </a> </li>
          <li> <a href="#DevTutorial"> Tutorial </a> </li>
@@ -33,8 +34,11 @@
                 <h2>Pre-Requisites</h2>
                 <div class="divider"><span></span></div>
      <ul class="iconsList">
-      <li><i class="icon-pin"></i> For 18.12, the ofbiz-framework trunk and ofbiz-plugins trunk the minimum requirement you need installed is Java 11 JDK.</li>
-      <li><i class="icon-pin"></i> Apache OFBiz can be downloaded and run on both Unix based and Windows based systems</li>
+      <li><i class="icon-pin"></i> For the ofbiz-framework trunk and ofbiz-plugins trunk the minimum requirement you need installed is Java 17 JDK (the full JDK, not just the JRE). Make sure to set the <code>$JAVA_HOME</code> environment variable.</li>
+      <li><i class="icon-pin"></i> For release 18.12, the minimum requirement is Java 11 JDK.</li>
+      <li><i class="icon-pin"></i> Apache OFBiz can be downloaded and run on both Unix based and Windows based systems.</li>
+      <li><i class="icon-pin"></i> On Windows, a PowerShell version &gt;= 7.1.3 is required (needed by the Gradle wrapper initialization script).</li>
+      <li><i class="icon-pin"></i> On Windows, do not install OFBiz in a directory whose path contains spaces.</li>
     </ul>
                  <p><strong>NOTE:</strong> If you are running an older release or branch then please refer to <a href="//cwiki.apache.org/confluence/display/OFBIZ/Home" target="external" >our Wiki</a> for details</p>
                 </div>
@@ -66,18 +70,25 @@
 
     </div>
             </section>
+      <section  id="DevGradle" class="slice row clearfix">
+              <div class="span10">
+                <h2>Initialize Gradle Wrapper</h2>
+                <div class="divider"><span></span></div>
+                <p>The Gradle wrapper is no longer bundled with the ofbiz-framework trunk source. Before running any <code>gradlew</code> command you must download the wrapper from the OFBiz top-level directory.</p>
+                <p>Run the following command for Unix-like OS</p>
+                <code>./gradle/init-gradle-wrapper.sh</code><p></p>
+                <p>Run the following command for MS Windows</p>
+                <code>init-gradle-wrapper</code>
+                <p></p>
+                <p><strong>NOTE:</strong> On Windows, if you encounter an error such as "Powershell is not recognized as an internal or external command, operable program or batch file", follow the advice at <a href="https://s.apache.org/vdcv8" target="external">https://s.apache.org/vdcv8</a>. If you run into problems, check the execution policy of PowerShell (see <a href="https://s.apache.org/urnju" target="external">https://s.apache.org/urnju</a>). By setting the execution policy to "unrestricted", you will be prompted to run the script once you run the <code>init-gradle-wrapper</code> command.</p>
+                <p><strong>NOTE:</strong> This step is only required once per checkout. Existing release branches (such as release18.12) ship the Gradle wrapper inside the repository and do not require this step.</p>
+              </div>
+            </section>
       <section  id="DevBldRun" class="slice row clearfix">
               <div class="span10">
                 <h2>Build and Run</h2>
                 <div class="divider"><span></span></div>
-                <p>Once you have downloaded the source code it will need to be built.</p>
-    <h3>Building Release 18.12</h3>
-    <p>To build 18.12 release, navigate to the OFBiz or framework-trunk directory and;</p>
-    <p>Run the following command for Unix-like OS</p>
-    <code>./gradlew cleanAll loadDefault</code><p></p>
-    <p>Run the following command for MS Windows</p>
-    <code>gradlew cleanAll loadDefault</code>
-    <p></p>
+                <p>Once you have downloaded the source code and (for trunk) initialized the Gradle wrapper, it will need to be built.</p>
     <h3>Building the Trunk</h3>
     <p>To build the trunk, navigate to the framework-trunk directory and;</p>
     <p>Run the following command for Unix-like OS</p>
@@ -85,7 +96,14 @@
     <p>Run the following command for MS Windows</p>
     <code>gradlew cleanAll loadAll</code>
     <p></p>
-    <h3>Starting and Running 18.12 or the ofbiz-framework trunk</h3>
+    <h3>Building Release 18.12</h3>
+    <p>To build 18.12 release, navigate to the OFBiz or framework-trunk directory and;</p>
+    <p>Run the following command for Unix-like OS</p>
+    <code>./gradlew cleanAll loadDefault</code><p></p>
+    <p>Run the following command for MS Windows</p>
+    <code>gradlew cleanAll loadDefault</code>
+    <p></p>
+    <h3>Starting and Running the ofbiz-framework trunk or 18.12</h3>
     <p>To start OFBiz running locally, navigate to the trunk directory and;</p>
     <p>Run the following command for Unix-like OS</p>
     <code>./gradlew ofbiz</code><p></p>

--- a/template/page/developers.tpl.php
+++ b/template/page/developers.tpl.php
@@ -81,7 +81,6 @@
                 <code>init-gradle-wrapper</code>
                 <p></p>
                 <p><strong>NOTE:</strong> On Windows, if you encounter an error such as "Powershell is not recognized as an internal or external command, operable program or batch file", follow the advice at <a href="https://s.apache.org/vdcv8" target="external">https://s.apache.org/vdcv8</a>. If you run into problems, check the execution policy of PowerShell (see <a href="https://s.apache.org/urnju" target="external">https://s.apache.org/urnju</a>). By setting the execution policy to "unrestricted", you will be prompted to run the script once you run the <code>init-gradle-wrapper</code> command.</p>
-                <p><strong>NOTE:</strong> This step is only required once per checkout. Existing release branches (such as release18.12) ship the Gradle wrapper inside the repository and do not require this step.</p>
               </div>
             </section>
       <section  id="DevBldRun" class="slice row clearfix">


### PR DESCRIPTION
## Summary
Follow-up to #15 (review feedback from @ashishvijaywargiya).

PR #15 was merged but updated only `developers.html` directly. Per the [site README](https://github.com/apache/ofbiz-site/blob/master/README.md), edits must be made to the PHP templates under `template/page/` and the HTML must be regenerated with `./php2html.sh`. This PR applies the same edits to `template/page/developers.tpl.php` so the template (source of truth) matches the already-merged HTML.

## What's in this PR
- Updates `template/page/developers.tpl.php` to mirror the content changes from #15:
  - New "Initialize Gradle Wrapper" section with `init-gradle-wrapper` / `./gradle/init-gradle-wrapper.sh` instructions
  - JDK 17 noted for trunk (JDK 11 retained for release 18.12), plus `$JAVA_HOME`, PowerShell ≥ 7.1.3, and "no spaces in install path" notes
  - Sidebar nav entry for the new section
  - "Building the Trunk" reordered before "Building Release 18.12"; start/run heading reworded to "trunk or 18.12"

## Why no HTML diff
Running `./php2html.sh` against the updated template produces an HTML output identical to the already-merged `developers.html`. Verified locally:

```
$ ./php2html.sh
$ git diff --stat developers.html
(no diff)
```

So no HTML changes are included in this commit — the existing HTML and the updated template are now in sync.

## Test plan
- [ ] Reviewer can run `./php2html.sh` and confirm `developers.html` is unchanged.
- [ ] Verify `template/page/developers.tpl.php` content matches the rendered page on https://ofbiz.apache.org/developers.html.
