### PR TITLE
Fixed: align developers.html file with its php template file

### DIFF
--- a/developers.html
+++ b/developers.html
@@ -180,7 +180,6 @@
                 <code>init-gradle-wrapper</code>
                 <p></p>
                 <p><strong>NOTE:</strong> On Windows, if you encounter an error such as "Powershell is not recognized as an internal or external command, operable program or batch file", follow the advice at <a href="https://s.apache.org/vdcv8" target="external">https://s.apache.org/vdcv8</a>. If you run into problems, check the execution policy of PowerShell (see <a href="https://s.apache.org/urnju" target="external">https://s.apache.org/urnju</a>). By setting the execution policy to "unrestricted", you will be prompted to run the script once you run the <code>init-gradle-wrapper</code> command.</p>
-                <p><strong>NOTE:</strong> This step is only required once per checkout. Existing release branches (such as release18.12) ship the Gradle wrapper inside the repository and do not require this step.</p>
               </div>
             </section>
       <section  id="DevBldRun" class="slice row clearfix">


### PR DESCRIPTION
This PR fixes a misalignment between template/page/developers.tpl.php and developers.html that was introduced with commit 1e0250540c8915f9aab306434a30cc11d08336ab